### PR TITLE
Allow exception_notification up version.

### DIFF
--- a/exception_notification-idobata.gemspec
+++ b/exception_notification-idobata.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'exception_notification', '~> 4.0.0'
+  gem.add_dependency 'exception_notification', '~> 4.0'
 
   gem.add_development_dependency 'bundler', '~> 1.5'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Latest exception_notification version is 4.1.4.
If we're already using exception_notification, troubled when install exception_notification-idobata.

```
Bundler could not find compatible versions for gem "exception_notification":
  In snapshot (Gemfile.lock):
    exception_notification (= 4.1.4)

  In Gemfile:
    exception_notification

    exception_notification-idobata was resolved to 0.0.1, which depends on
      exception_notification (~> 4.0.0)
```

So,  please allow exception_notification up version.
``` gem.add_dependency 'exception_notification', '~> 4.0' ```
I tryed exception_notification-idobata with exception_notification (= 4.1.4), it seems no problem.